### PR TITLE
Fix addBefore and addAfter

### DIFF
--- a/src/List/Unique.elm
+++ b/src/List/Unique.elm
@@ -191,7 +191,7 @@ addBefore target new (UniqueList list) =
     if new == target then
         UniqueList list
 
-    else if List.member new list then
+    else if List.member new list && List.member target list then
         list
             |> filterFor new
             |> List.foldr (addBeforeHelper target new) []
@@ -235,7 +235,7 @@ addAfter target new (UniqueList list) =
     if new == target then
         UniqueList list
 
-    else if List.member new list then
+    else if List.member new list && List.member target list then
         list
             |> filterFor new
             |> List.foldr (addAfterHelper target new) []

--- a/src/List/Unique.elm
+++ b/src/List/Unique.elm
@@ -187,14 +187,20 @@ new position.
 
 -}
 addBefore : a -> a -> UniqueList a -> UniqueList a
-addBefore el newEl (UniqueList list) =
-    if newEl /= el then
+addBefore target new (UniqueList list) =
+    if new == target then
+        UniqueList list
+
+    else if List.member new list then
         list
-            |> List.foldr (addBeforeHelper el newEl) []
+            |> filterFor new
+            |> List.foldr (addBeforeHelper target new) []
             |> fromList
 
     else
-        UniqueList list
+        list
+            |> List.foldr (addBeforeHelper target new) []
+            |> fromList
 
 
 addBeforeHelper : a -> a -> a -> List a -> List a
@@ -225,14 +231,20 @@ new position.
 
 -}
 addAfter : a -> a -> UniqueList a -> UniqueList a
-addAfter el newEl (UniqueList list) =
-    if newEl /= el then
+addAfter target new (UniqueList list) =
+    if new == target then
+        UniqueList list
+
+    else if List.member new list then
         list
-            |> List.foldr (addAfterHelper el newEl) []
+            |> filterFor new
+            |> List.foldr (addAfterHelper target new) []
             |> fromList
 
     else
-        UniqueList list
+        list
+            |> List.foldr (addAfterHelper target new) []
+            |> fromList
 
 
 addAfterHelper : a -> a -> a -> List a -> List a


### PR DESCRIPTION
`addBefore` and `addAfter` did not behave as described in the docs. This PR aims to fix the problem until a better solution can be found.

The actual behaviour was to produce a UniqueList from the result of adding an element before/after another, but his is not an intuitive or particularly useful behaviour.